### PR TITLE
Add support for loclist for QInfo

### DIFF
--- a/autoload/kickfix.vim
+++ b/autoload/kickfix.vim
@@ -71,13 +71,14 @@ endfun
 " QInfo {{{1
 " Print number of files and number of errors in the quickfix
 function! kickfix#QInfo() abort
-  let files = empty(getqflist())
+  let curlist = !empty(getloclist(0)) ? getloclist(0) : getqflist()
+  let files = empty(curlist)
         \ ? {}
         \ : eval('{'.
-        \ join(uniq(map(getqflist(),'v:val.bufnr'),'N'),':1,').
+        \ join(uniq(map(copy(curlist),'v:val.bufnr'),'N'),':1,').
         \ ':1}')
 
-  echo printf("%d File(s), %d Line(s)", len(files), len(getqflist()))
+  echo printf("%d File(s), %d Line(s)", len(files), len(curlist))
 endfunction
 
 " QDeleteLine {{{1

--- a/autoload/kickfix.vim
+++ b/autoload/kickfix.vim
@@ -68,6 +68,18 @@ function! kickfix#QFilterContent(rx, filter_in) abort
   endif
 endfun
 
+" QInfo {{{1
+" Print number of files and number of errors in the quickfix
+function! kickfix#QInfo() abort
+  let files = empty(getqflist())
+        \ ? {}
+        \ : eval('{'.
+        \ join(uniq(map(getqflist(),'v:val.bufnr'),'N'),':1,').
+        \ ':1}')
+
+  echo printf("%d File(s), %d Line(s)", len(files), len(getqflist()))
+endfunction
+
 " QDeleteLine {{{1
 " Remove line(s) from quickfix
 function! kickfix#QDeleteLine(...) abort

--- a/plugin/kickfix.vim
+++ b/plugin/kickfix.vim
@@ -6,12 +6,7 @@ command! -nargs=1 -bar -bang QFilterName
 command! -nargs=1 -bar -bang QFilterContent
       \ call kickfix#QFilterContent(<q-args>, '<bang>'=='')
 
-command! -bar QInfo
-      \ echo printf("%d File(s), %d Line(s)",
-      \   len(eval('{'.
-      \     join(uniq(map(getqflist(),'v:val.bufnr'),'N'),':1,').
-      \     ':1}')),
-      \   len(getqflist()))
+command! -bar QInfo call kickfix#QInfo()
 
 command! -range -bar QDeleteLine
       \ call kickfix#QDeleteLine(<line1>, <line2>)


### PR DESCRIPTION
As of now, running `:QInfo` from a loclist presents the following error:

```
E121: Undefined variable: :1
E15: Invalid expression: :1
E15: Invalid expression: {:1}
1 File(s), 0 Line(s)
Press ENTER or type command to continue
```

This is a patch for this behavior, as well as the general case of an empty quickfix/loclist.