### PR TITLE
Add loclist support

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -2,10 +2,3 @@
 
 let b:undo_ftplugin = "setl number< nowrap<"
 setl number nowrap
-
-nnoremap <buffer><silent> dd :QDeleteLine<cr>
-nnoremap <buffer><silent> d  :set opfunc=kickfix#QDeleteLine<cr>g@
-xnoremap <buffer><silent> d  :QDeleteLine<cr>
-
-nnoremap <buffer><silent> <Plug>(KickfixPreview)
-      \ :<C-u>call kickfix#Preview()<cr>

--- a/autoload/kickfix.vim
+++ b/autoload/kickfix.vim
@@ -48,13 +48,13 @@ endfunction
 
 " QFilterContent {{{1
 " Filter in/out quickfix entries by content
-function! kickfix#QFilterContent(rx, filter_in) abort
-  let nqf = []
-  let g:oldqf = getqflist()
+function! s:FilterContent(list, rx, filter_in) abort
+  let newlist = []
+  let oldlist = a:list
   let [kept, removed, nobuf] = [0, 0, 0]
   let winid = win_getid()
   1split
-  for f in g:oldqf
+  for f in oldlist
     if !get(f, 'bufnr', 0)
       let nobuf += 1
       continue
@@ -62,19 +62,27 @@ function! kickfix#QFilterContent(rx, filter_in) abort
     exe 'noauto b' f.bufnr
     if (a:filter_in && search(a:rx, 'wn'))
           \ || (!a:filter_in && !search(a:rx, 'wn'))
-      call add(nqf, copy(f))
+      call add(newlist, copy(f))
       let kept += 1
     else
       let removed += 1
     endif
   endfor
   echom printf('Removed: %d, Kept: %d, Nobuf: %d', removed, kept, nobuf)
-  call setqflist(nqf)
   close
   if win_id2win(winid)
     call win_gotoid(winid)
   endif
+  return newlist
+endfunction
+
+function! kickfix#QFilterContent(rx, filter_in) abort
+  call setqflist(s:FilterContent(getqflist(), a:rx, a:filter_in))
 endfun
+
+function! kickfix#LocFilterContent(rx, filter_in) abort
+  call setloclist(0, s:FilterContent(getloclist(0), a:rx, a:filter_in))
+endfunction
 
 " QInfo {{{1
 " Print number of files and number of errors in the quickfix

--- a/autoload/kickfix.vim
+++ b/autoload/kickfix.vim
@@ -16,11 +16,11 @@ endfun
 
 " QFilterName {{{1
 " Filter in/out quickfix entries by filename
-function! kickfix#QFilterName(rx, filter_in) abort
-  let nqf = []
-  let g:oldqf = getqflist()
+function! s:FilterName(list, rx, filter_in) abort
+  let newlist = []
+  let oldlist = a:list
   let [kept, removed, nobuf] = [0, 0, 0]
-  for f in g:oldqf
+  for f in oldlist
     if !get(f, 'bufnr', 0)
       let nobuf += 1
       continue
@@ -28,15 +28,23 @@ function! kickfix#QFilterName(rx, filter_in) abort
     let bufname = bufname(f.bufnr)
     if (a:filter_in && match(bufname, a:rx) != -1)
           \ || (!a:filter_in && match(bufname, a:rx) == -1)
-      call add(nqf, copy(f))
+      call add(newlist, copy(f))
       let kept += 1
     else
       let removed += 1
     endif
   endfor
   echom printf('Removed: %d, Kept: %d, Nobuf: %d', removed, kept, nobuf)
-  call setqflist(nqf)
+  return newlist
+endfunction
+
+function! kickfix#QFilterName(rx, filter_in) abort
+  call setqflist(s:FilterName(getqflist(), a:rx, a:filter_in))
 endfun
+
+function! kickfix#LocFilterName(rx, filter_in) abort
+  call setloclist(0, s:FilterName(getloclist(0), a:rx, a:filter_in))
+endfunction
 
 " QFilterContent {{{1
 " Filter in/out quickfix entries by content

--- a/autoload/kickfix.vim
+++ b/autoload/kickfix.vim
@@ -125,10 +125,11 @@ endfun
 
 " QLoad {{{1
 " Load saved quickfix buffer
-function! kickfix#QLoad(file) abort
+function! kickfix#QLoad(file, loc) abort
+  let cmd = a:loc ? "lfile" : "cfile"
   let oldefm = &efm
   setlocal efm+=%f\|%l\ col\ %c\|%m
-  exe "cfile" a:file
+  exe cmd a:file
   let &efm = oldefm
 endfun
 

--- a/autoload/kickfix.vim
+++ b/autoload/kickfix.vim
@@ -100,6 +100,8 @@ endfunction
 " QDeleteLine {{{1
 " Remove line(s) from quickfix
 function! kickfix#QDeleteLine(...) abort
+  let isloc = !empty(getloclist(0))
+  let curlist = isloc ? getloclist(0) : getqflist()
   if a:0 == 1 && type(a:1) == type("")
     " called from g@
     let [l1, l2] = [line("'["), line("']")]
@@ -111,10 +113,13 @@ function! kickfix#QDeleteLine(...) abort
     return
   endif
   let curline = line('.')
-  let g:oldqf = getqflist()
-  let nqf = copy(g:oldqf)
-  call remove(nqf, l1 - 1, l2 - 1)
-  call setqflist(nqf)
+  let newlist = copy(curlist)
+  call remove(newlist, l1 - 1, l2 - 1)
+  if isloc
+    call setloclist(0, newlist)
+  else
+    call setqflist(newlist)
+  endif
   call cursor(curline, 0)
 endfun
 

--- a/doc/kickfix.txt
+++ b/doc/kickfix.txt
@@ -49,22 +49,32 @@ COMMANDS                                                     *kickfix-commands*
 
 :[range]QDeleteLine                                              *:QDeleteLine*
   Delete lines from the quickfix buffer and the corresponding entries
-  from the quickfix list.
+  from the quickfix list. Also works for the location list.
 
 :QFilterName[!] {pattern}                                        *:QFilterName*
-  Keep only filenames matching {pattern}.
+  Keep only filenames matching {pattern} in the quickfix list.
+  Discard them if [!].
+
+:LocFilterName[!] {pattern}                                    *:LocFilterName*
+  Keep only filenames matching {pattern} in the location list.
   Discard them if [!].
 
 :QFilterContent[!] {pattern}                                  *:QFilterContent*
-  Keep only files whose content matches {pattern}.
+  Keep only files whose content matches {pattern} in the quickfix list.
+  Discard them if [!].
+
+:LocFilterContent[!] {pattern}                              *:LocFilterContent*
+  Keep only files whose content matches {pattern} in the location list.
   Discard them if [!].
 
 :QInfo                                                                 *:QInfo*
-  Show number of files and number of entries in the quickfix list.
+  Show number of files and number of entries in the quickfix list. Also works
+  for the location list.
 
 :QLoad {path}                                                          *:QLoad*
   Load quickfix from {path}.
-  Quickfix content can be saved as is with `:w {path}`.
+  Quickfix content can be saved as is with `:w {path}`. Also works for the
+  location list.
 
 =============================================================================
 PLUG MAPPINGS                                           *kickfix-plug-mappings*

--- a/plugin/kickfix.vim
+++ b/plugin/kickfix.vim
@@ -7,6 +7,8 @@ command! -nargs=1 -bar -bang LocFilterName
 
 command! -nargs=1 -bar -bang QFilterContent
       \ call kickfix#QFilterContent(<q-args>, '<bang>'=='')
+command! -nargs=1 -bar -bang LocFilterContent
+      \ call kickfix#LocFilterContent(<q-args>, '<bang>'=='')
 
 command! -bar QInfo call kickfix#QInfo()
 

--- a/plugin/kickfix.vim
+++ b/plugin/kickfix.vim
@@ -16,5 +16,7 @@ command! -range -bar QDeleteLine
       \ call kickfix#QDeleteLine(<line1>, <line2>)
 
 command! -bar -nargs=1 -complete=file QLoad
-      \ call kickfix#QLoad(<q-args>)
+      \ call kickfix#QLoad(<q-args>, 0)
+command! -bar -nargs=1 -complete=file LocLoad
+      \ call kickfix#QLoad(<q-args>, 1)
 

--- a/plugin/kickfix.vim
+++ b/plugin/kickfix.vim
@@ -2,6 +2,8 @@
 
 command! -nargs=1 -bar -bang QFilterName
       \ call kickfix#QFilterName(<q-args>, '<bang>'=='')
+command! -nargs=1 -bar -bang LocFilterName
+      \ call kickfix#LocFilterName(<q-args>, '<bang>'=='')
 
 command! -nargs=1 -bar -bang QFilterContent
       \ call kickfix#QFilterContent(<q-args>, '<bang>'=='')


### PR DESCRIPTION
Some commands are overloaded to work in both the quickfix and the loclist (`QDeleteLine` and the previously merged `QInfo`), while some commands explicitly have loclist versions (`LocFilterName`, `LocFilterContent`, `LocLoad`).

This depends on whether a user will primarily run the command from within a quickfix window alone (e.g. `QDeleteLine` designed specifically to be used this way, so overloading is fine), or if the user will run the command from arbitrary windows (e.g. `QFilterName`, which can be ambiguous if both the quickfix and the loclist have entries).